### PR TITLE
feat: bump ecs-task to 0.6.0

### DIFF
--- a/ecs-runtask.cfhighlander.rb
+++ b/ecs-runtask.cfhighlander.rb
@@ -14,6 +14,6 @@ CfhighlanderTemplate do
   end
 
   #Pass the all the config from the parent component to the inlined component
-  Component template: 'ecs-task@0.5.16', name: "#{component_name.gsub('-','').gsub('_','')}Task", render: Inline, config: @config 
+  Component template: 'ecs-task@0.6.0', name: "#{component_name.gsub('-','').gsub('_','')}Task", render: Inline, config: @config 
 
 end


### PR DESCRIPTION
Bumps `ecs-task` dependency from 0.5.16 to 0.6.0.

### New features in ecs-task 0.6.0:
- **Hash format for volumes** — `volumes: {name: {host_path: /path}}`
- **`mount_points` key** — CFN-style mount point objects in task definitions

This enables the following config in ecs-runtask:

```yaml
volumes:
  s3-data:
    host_path: /mnt/s3

task_definition:
  train:
    mount_points:
      - ContainerPath: /mnt/s3
        SourceVolume: s3-data
        ReadOnly: false
```

Release: https://github.com/theonestack/hl-component-ecs-task/releases/tag/0.6.0